### PR TITLE
Implement -[init] methods to get rid of warning.

### DIFF
--- a/APOfflineReverseGeocoding/APCountry.m
+++ b/APOfflineReverseGeocoding/APCountry.m
@@ -16,6 +16,11 @@
     return [[self alloc] initWithGeoDictionary:dictionary];
 }
 
+- (instancetype)init {
+    NSAssert(NO, @"use initWithGeoDictionary:");
+    return nil;
+}
+
 - (instancetype)initWithGeoDictionary:(NSDictionary *)dictionary
 {
     self = [super init];

--- a/APOfflineReverseGeocoding/APReverseGeocoding.m
+++ b/APOfflineReverseGeocoding/APReverseGeocoding.m
@@ -23,9 +23,7 @@ static NSString *const APReverseGeocodingCountriesKey  = @"features";
 
 + (instancetype)defaultGeocoding
 {
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-    NSURL *url = [bundle URLForResource:APReverseGeocodingDefaultDBName withExtension:@"json"];
-    return [self geocodingWithGeoJSONURL:url];
+    return [[self alloc] init];
 }
 
 + (instancetype)geocodingWithGeoJSONURL:(NSURL *)url
@@ -41,6 +39,12 @@ static NSString *const APReverseGeocodingCountriesKey  = @"features";
         _url = url;
     }
     return self;
+}
+
+- (instancetype)init {
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSURL *url = [bundle URLForResource:APReverseGeocodingDefaultDBName withExtension:@"json"];
+    return [self initWithGeoJSONURL:url];
 }
 
 #pragma mark - Public

--- a/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.m
+++ b/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.m
@@ -34,6 +34,11 @@
     return self;
 }
 
+- (instancetype)init {
+    NSAssert(NO, @"use initWithCountryCode:");
+    return nil;
+}
+
 #pragma mark - Public
 
 - (NSDictionary *)build


### PR DESCRIPTION
Xcode gives the warning "method override for the designated initializer of the superclass '-init' not found" for classes APCountry, APReverseGeocoding and APCountryInfoBuilder.
