### PR TITLE
Set init methods as NS_UNAVAILABLE to get rid of warnings.

### DIFF
--- a/APOfflineReverseGeocoding/APCountry.h
+++ b/APOfflineReverseGeocoding/APCountry.h
@@ -29,6 +29,8 @@
  */
 - (instancetype)initWithGeoDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /* Represents country 3 digits code ISO 3166-1 Alpha 3 */
 @property (nonatomic, copy, readonly) NSString *code;
 

--- a/APOfflineReverseGeocoding/APReverseGeocoding.h
+++ b/APOfflineReverseGeocoding/APReverseGeocoding.h
@@ -38,6 +38,8 @@
  */
 - (instancetype)initWithGeoJSONURL:(NSURL *)url __attribute__((nonnull)) NS_DESIGNATED_INITIALIZER;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 @property (nonatomic, strong, readonly) NSURL *url;
 
 /**

--- a/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.h
+++ b/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.h
@@ -29,6 +29,8 @@
  */
 - (instancetype)initWithCountryCode:(NSString *)countryCode NS_DESIGNATED_INITIALIZER;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  *  Imports the country info
  *


### PR DESCRIPTION
This should be the proper way of disabling "init" when the designated initializer needs a parameter and there is no appropriate way of overriding init. 
