### PR TITLE
Log error instead of parsedJSON, which is likely nil

### DIFF
--- a/APOfflineReverseGeocoding/APReverseGeocoding.m
+++ b/APOfflineReverseGeocoding/APReverseGeocoding.m
@@ -117,7 +117,7 @@ static NSString *const APReverseGeocodingCountriesKey  = @"features";
         if (!error) {
             _geoJSON = [parsedJSON copy];
         } else {
-            [NSException raise:@"Cannot parse JSON." format:@"JSON URL - %@\nError:%@", self.url, parsedJSON];
+            [NSException raise:@"Cannot parse JSON." format:@"JSON URL - %@\nError:%@", self.url, error];
         }
     }
     return _geoJSON;


### PR DESCRIPTION
We got a crash on this line, which is odd of course since this file is bundled. It would be good if the error was logged in the exception message, which seems to have been the intention here. 