### PR TITLE
Fix warnings related to empty initializers

### DIFF
--- a/APOfflineReverseGeocoding/APCountry.h
+++ b/APOfflineReverseGeocoding/APCountry.h
@@ -50,9 +50,7 @@
 /* Represents country calendar */
 @property (nonatomic, strong, readonly) NSCalendar *calendar;
 
-@end
-
-@interface APCountry (Unavailable)
+#pragma mark - Mark init and new as unavailable
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/APOfflineReverseGeocoding/APCountry.m
+++ b/APOfflineReverseGeocoding/APCountry.m
@@ -16,11 +16,6 @@
     return [[self alloc] initWithGeoDictionary:dictionary];
 }
 
-- (instancetype)init
-{
-    return nil;
-}
-
 - (instancetype)initWithGeoDictionary:(NSDictionary *)dictionary
 {
     self = [super init];

--- a/APOfflineReverseGeocoding/APReverseGeocoding.h
+++ b/APOfflineReverseGeocoding/APReverseGeocoding.h
@@ -49,9 +49,7 @@
  */
 - (APCountry *)geocodeCountryWithCoordinate:(CLLocationCoordinate2D)coordinate;
 
-@end
-
-@interface APReverseGeocoding (Unavailable)
+#pragma mark - Mark init and new as unavailable
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/APOfflineReverseGeocoding/APReverseGeocoding.m
+++ b/APOfflineReverseGeocoding/APReverseGeocoding.m
@@ -28,11 +28,6 @@ static NSString *const APReverseGeocodingCountriesKey  = @"features";
     return [self geocodingWithGeoJSONURL:url];
 }
 
-- (instancetype)init
-{
-    return nil;
-}
-
 + (instancetype)geocodingWithGeoJSONURL:(NSURL *)url
 {
     return [[self alloc] initWithGeoJSONURL:url];

--- a/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.h
+++ b/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.h
@@ -36,9 +36,7 @@
  */
 - (NSDictionary *)build;
 
-@end
-
-@interface APCountryInfoBuilder (Unavailable)
+#pragma mark - Mark init and new as unavailable
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.m
+++ b/APOfflineReverseGeocoding/Internal/APCountryInfoBuilder.m
@@ -25,11 +25,6 @@
     return [[self alloc] initWithCountryCode:countryCode];
 }
 
-- (instancetype)init
-{
-    return nil;
-}
-
 - (instancetype)initWithCountryCode:(NSString *)countryCode
 {
     self = [super init];

--- a/APOfflineReverseGeocoding/Internal/APPolygon.h
+++ b/APOfflineReverseGeocoding/Internal/APPolygon.h
@@ -39,6 +39,11 @@
  */
 - (BOOL)containsPoint:(CGPoint)point;
 
+#pragma mark - Mark init and new as unavailable
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 @end
 
 @interface APPolygon (CoreLocation)
@@ -51,12 +56,5 @@
  *  @return contains location BOOL
  */
 - (BOOL)containsLocation:(CLLocationCoordinate2D)location;
-
-@end
-
-@interface APPolygon (Unavailable)
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
 
 @end


### PR DESCRIPTION
With current Xcode, you get warnings on the “empty” inits that just return nil:
“Implementing unavailable method”

If you remove them, you get the warning:
“Method override for the designated initializer of the superclass '-init' not found”
The NS_UNAVAILABLE inits need to be in the main interface, not an extension.